### PR TITLE
fix encode pubkey as binary in NIP-19 nevent encoding

### DIFF
--- a/lib/client/nip19/nip19_tlv.dart
+++ b/lib/client/nip19/nip19_tlv.dart
@@ -190,7 +190,7 @@ class NIP19Tlv {
       }
     }
     if (o.author != null) {
-      TLVUtil.writeTLVEntry(buf, TLVType.Author, utf8.encode(o.author!));
+      TLVUtil.writeTLVEntry(buf, TLVType.Author, HEX.decode(o.author!));
     }
 
     buf = Nip19.convertBits(buf, 8, 5, true);


### PR DESCRIPTION
## Why

I found the bug in NIP-19 `nevent1...` encoding process. This PR fixes it.

The `author` TLV entry (`T=2`) should be binary (byte array) but nostrmo encode it as hex string. I checked the code and found the cause: `HEX.decode()` should be used instead of `utf8.encode()`.

The decoding implementation use `HEX.encode()` for `author` entry:
https://github.com/haorendashu/nostrmo/blob/dccf34e119ddf1e0c12306f75b8dc38be0d217a7/lib/client/nip19/nip19_tlv.dart#L92

## Test vector
- `nevent1qqspeyc4xxjh0ddrw3m3e6kmxwpudg6sx4jm8hq5u77srdgk8vy4luqpzpmhxue69uhkummnw3ezuamfdejsysrrvs6rqwrpxcukxcekvvmnxdmrvyckzdekv4nxxvmxvyergdmrxe3kzdfnv43nsvphvcmx2dmr8y6nwdp3xc6rzd35xuunwefcxymrysk7txj`